### PR TITLE
fix: File separator being / instead of \\ in git bash on windows

### DIFF
--- a/mpvremote/main.js
+++ b/mpvremote/main.js
@@ -19,7 +19,7 @@ var options = {
 
 mp.options.read_options(options, "mpvremote");
 
-var platform = mp.utils.getenv("windir") ? "win32" : "unix";
+var platform = mp.utils.getenv("windir") || mp.utils.getenv("WINDIR") ? "win32" : "unix";
 var tempdir = mp.utils.getenv("TEMP") || mp.utils.getenv("TMP") || "/tmp"; // Temp dir
 var pathsep = platform === "win32" ? "\\" : "/";
 


### PR DESCRIPTION
Tested on windows git bash, powershell, zsh on linux and WSL. All acting as expected. 