### PR TITLE
Add ".iso" extension to fileformats.js

### DIFF
--- a/fileformats.js
+++ b/fileformats.js
@@ -138,6 +138,7 @@ const FILE_FORMATS = {
     ".3gp",
     ".3gp2",
     ".3g2",
+    ".iso",
   ],
   playlist: [".m3u", ".m3u8", ".pls"],
   subtitle: [


### PR DESCRIPTION
mpv is capable of playing a disc image in the .iso format directly