### PR TITLE
Guard against path-traversal in filebrowser

### DIFF
--- a/filebrowser.js
+++ b/filebrowser.js
@@ -130,8 +130,10 @@ router.post("/api/v1/filebrowser/browse", async (req, res) => {
     if (p) {
       // If unsafe filebrowsing disabled we've to check FILEBROWSER_PATHS
       if (!settings.unsafefilebrowsing) {
+        // Security: Protect against path-traversal attack by resolving synlinks and ..
+        p = await fs_async.realpath(p);
         let fbe = settings.filebrowserPaths.find((el) => {
-          return p.includes(el.path);
+          return p.startsWith(el.path);
         });
 
         if (!fbe)


### PR DESCRIPTION
Before, you could escape from the `filebrowserpaths`, effectively rendering the security improvements from disabling `unsafefilebrowsing` useless:
```bash
~ $ curl "http://192.168.0.4:8000/api/v1/filebrowser/paths"
[{"index":0,"path":"/mnt/media"}]
~ $ curl -H 'Content-Type: application/json' -d '{"path":"/mnt"}' "http://192.168.0.4:8000/api/v1/filebrowser/browse"
{"message":"Path not exists on filebrowserpaths: /mnt"}

# This should return the same error. Instead, directory contents are returned
~ $ curl -H 'Content-Type: application/json' -d '{"path":"/mnt/media/.."}' "http://192.168.0.4:8000/api/v1/filebrowser/browse"
{"content":[{"priority":1,"type":"directory","name":"caviARchive","fullPath":"/mnt/caviARchive","lastModified":"2023-07-14T21:52:09.716Z"},{"priority":1,"type":"directory","name":"green","fullPath":"/mnt/green","lastModified":"2023-09-24T00:45:30.384Z"},{"priority":1,"type":"directory","name":"iso","fullPath":"/mnt/iso","lastModified":"2022-01-29T22:34:08.530Z"},{"priority":1,"type":"directory","name":"media","fullPath":"/mnt/media","lastModified":"2023-12-17T03:00:08.878Z"}],"dirname":"..","prevDir":"/","cwd":"/mnt/media/.."}
```
To guard against this, call `realpath` to resolve any symlinks or `..`, and restrict the comparison to  `startsWith`